### PR TITLE
Update Extensions Event Hubs and Extensions Storage sdk from t1 to t2

### DIFF
--- a/GapBackfill/Functions/Creator.cs
+++ b/GapBackfill/Functions/Creator.cs
@@ -25,13 +25,13 @@ namespace Azure.Samples.ReliableEdgeRelay.Functions
             ILogger logger,
             ExecutionContext context)
         {
-            var exceptions = new List<RequestFailedException>();
+            var exceptions = new List<Exception>();
 
             foreach (EventData eventData in inputEvents)
             {
                 try
                 {
-                    byte[] messageBody = eventData.EventBody.ToArray();
+                    string messageBody = eventData.EventBody.ToString();
 
                     logger.LogInformation($"{context.FunctionName}: {messageBody}");
 
@@ -56,7 +56,7 @@ namespace Azure.Samples.ReliableEdgeRelay.Functions
                         await Task.Yield();
                     }
                 }
-                catch (RequestFailedException e)
+                catch (Exception e)
                 {
                     exceptions.Add(e);
                 }

--- a/GapBackfill/Functions/Creator.cs
+++ b/GapBackfill/Functions/Creator.cs
@@ -69,7 +69,6 @@ namespace Azure.Samples.ReliableEdgeRelay.Functions
 
             if (exceptions.Count == 1)
                 ExceptionDispatchInfo.Capture(exceptions.Single()).Throw();
-
         }
     }
 }

--- a/GapBackfill/Functions/Executor.cs
+++ b/GapBackfill/Functions/Executor.cs
@@ -26,13 +26,13 @@ namespace Azure.Samples.ReliableEdgeRelay.Functions
             ILogger logger,
             ExecutionContext context)
         {
-            var exceptions = new List<RequestFailedException>();
+            var exceptions = new List<Exception>();
 
             foreach (EventData eventData in inputEvent)
             {
                 try
                 {
-                    byte[] messageBody = eventData.EventBody.ToArray();
+                    string messageBody = eventData.EventBody.ToString();
 
                     logger.LogInformation($"{context.FunctionName}: {messageBody}");
 
@@ -62,7 +62,7 @@ namespace Azure.Samples.ReliableEdgeRelay.Functions
                         await Task.Yield();
                     }
                 }
-                catch (RequestFailedException e)
+                catch (Exception e)
                 {
                     exceptions.Add(e);
                 }

--- a/GapBackfill/Functions/Processor.cs
+++ b/GapBackfill/Functions/Processor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
@@ -53,9 +54,9 @@ namespace Azure.Samples.ReliableEdgeRelay.Functions
                 }
 
             }
-            catch (RequestFailedException e)
+            catch (Exception e)
             {
-                log.LogError($"Error in {context.FunctionName}: {e.ToString()}");
+                log.LogError($"Error in {context.FunctionName}: {e}");
                 throw;
             }
         }

--- a/GapBackfill/Functions/Processor.cs
+++ b/GapBackfill/Functions/Processor.cs
@@ -1,10 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-
 using Newtonsoft.Json;
 
 namespace Azure.Samples.ReliableEdgeRelay.Functions
@@ -56,7 +53,7 @@ namespace Azure.Samples.ReliableEdgeRelay.Functions
                 }
 
             }
-            catch (Exception e)
+            catch (RequestFailedException e)
             {
                 log.LogError($"Error in {context.FunctionName}: {e.ToString()}");
                 throw;

--- a/GapBackfill/GapBackfill.csproj
+++ b/GapBackfill/GapBackfill.csproj
@@ -1,17 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Azure.Storage.Queue" Version="11.1.3" />
-    <PackageReference Include="Microsoft.Azure.Storage.Common" Version="11.1.3" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.20.0" />
   </ItemGroup>
   <ItemGroup>

--- a/GapBackfill/GapBackfill.csproj
+++ b/GapBackfill/GapBackfill.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v2</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage.Queues" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />

--- a/GapBackfill/Helpers/IoTHelpers.cs
+++ b/GapBackfill/Helpers/IoTHelpers.cs
@@ -1,7 +1,5 @@
-
 using System;
 using System.Threading.Tasks;
-
 using Microsoft.Azure.Devices;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;

--- a/GapBackfill/Helpers/SqlHelpers.cs
+++ b/GapBackfill/Helpers/SqlHelpers.cs
@@ -2,9 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Threading.Tasks;
-
 using Microsoft.Extensions.Logging;
-
 using Newtonsoft.Json;
 
 namespace Azure.Samples.ReliableEdgeRelay.Helpers


### PR DESCRIPTION
1.Update Extensions Event Hubs and Extensions Storage sdk from t1 to t2

2.Update files:

i.  GapBackfill/Functions/Creator.cs
ii. GapBackfill/Functions/Executor.cs
iii. GapBackfill/Functions/Processor.cs
iv. GapBackfill/GapBackfill.csproj
v. GapBackfill/Helpers/IoTHelpers.cs
vi. GapBackfill/Helpers/SqlHelpers.cs

@scottaddie,@AlexGhiondea,@JoshLove-msft and @amnguye for notification.